### PR TITLE
A couple of small fixes

### DIFF
--- a/JGMethodSwizzler/JGMethodSwizzler.h
+++ b/JGMethodSwizzler/JGMethodSwizzler.h
@@ -32,7 +32,7 @@ typedef id (^JGMethodReplacementProvider)(JG_IMP original, __unsafe_unretained C
  @return \c YES if any methods have been deswizzled successfully.
  */
 
-OBJC_EXTERN BOOL deswizzleGlobal();
+OBJC_EXTERN BOOL deswizzleGlobal(void);
 
 
 /**
@@ -41,7 +41,7 @@ OBJC_EXTERN BOOL deswizzleGlobal();
  @return \c YES if any methods have been deswizzled successfully.
  */
 
-OBJC_EXTERN BOOL deswizzleInstances();
+OBJC_EXTERN BOOL deswizzleInstances(void);
 
 
 /**
@@ -50,7 +50,7 @@ OBJC_EXTERN BOOL deswizzleInstances();
  @return \c YES if any methods have been deswizzled successfully.
  */
 
-OBJC_EXTERN BOOL deswizzleAll();
+OBJC_EXTERN BOOL deswizzleAll(void);
 
 
 //-----------------

--- a/JGMethodSwizzler/JGMethodSwizzler.m
+++ b/JGMethodSwizzler/JGMethodSwizzler.m
@@ -704,7 +704,8 @@ NS_INLINE void swizzleInstance(__unsafe_unretained id object, SEL selector, JGMe
 
 #pragma mark - Public functions
 
-BOOL deswizzleGlobal() {
+BOOL deswizzleGlobal(void)
+{
     BOOL success = NO;
     OSSpinLockLock(&lock);
     NSDictionary *d = originalClassMethods.copy;
@@ -735,7 +736,8 @@ BOOL deswizzleGlobal() {
 }
 
 
-BOOL deswizzleInstances() {
+BOOL deswizzleInstances(void)
+{
     OSSpinLockLock(&lock);
     BOOL success = NO;
     NSDictionary *d = dynamicSubclassesByObject.copy;
@@ -755,7 +757,8 @@ BOOL deswizzleInstances() {
     return success;
 }
 
-BOOL deswizzleAll() {
+BOOL deswizzleAll(void)
+{
     BOOL a = deswizzleGlobal();
     BOOL b = deswizzleInstances();
     

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Swizzling the method `+(int)[TestClass test:(int)]`
 	//return a replacement block
 	return JGMethodReplacement(int, const Class *, int arg) {
 		//get the original value
-		int orig = JGCastOriginal(int, arg);
+		int orig = JGOriginalImplementation(int, arg);
 		//return the modified value
 		return orig+2;
 	};
@@ -40,7 +40,7 @@ Swizzling the method `-(int)[TestClass test:(int)]`
 	//return a replacement block
 	return JGMethodReplacement(int, TestClass *, int arg) {
 		//get the original value
-		int orig = JGCastOriginal(int, arg);
+		int orig = JGOriginalImplementation(int, arg);
 		//return the modified value
 		return orig+2;
 	};
@@ -58,7 +58,7 @@ NSObject *object = [NSObject new];
 
 [object swizzleMethod:@selector(description) withReplacement:JGMethodReplacementProviderBlock {
 	return JGMethodReplacement(NSString *, NSObject *) {
-		NSString *orig = JGCastOriginal(NSString *);
+		NSString *orig = JGOriginalImplementation(NSString *);
             
 		return [orig stringByAppendingString:@" Swizzled!!"];
 	};


### PR DESCRIPTION
- Use void in C function prototypes to shut up Xcode.
- Fixed documentation to use the correct JGOriginalImplementation macro.

Thanks for a very useful library!
