### PR TITLE
Fix documentation build warnings

### DIFF
--- a/JGMethodSwizzler/JGMethodSwizzler.h
+++ b/JGMethodSwizzler/JGMethodSwizzler.h
@@ -74,7 +74,7 @@ OBJC_EXTERN BOOL deswizzleAll(void);
  Swizzle the specified class method.
  
  @param selector Selector of the method to swizzle.
- @param replacement The replacement block to use for swizzling the method. Its signature needs to be: return_type ^(id self, ...).
+ @param replacementProvider The replacement block to use for swizzling the method. Its signature needs to be: return_type ^(id self, ...).
  
  */
 
@@ -85,7 +85,7 @@ OBJC_EXTERN BOOL deswizzleAll(void);
  Swizzle the specified instance method.
  
  @param selector Selector of the method to swizzle.
- @param replacement The replacement block to use for swizzling the method. Its signature needs to be: return_type ^(id self, ...).
+ @param replacementProvider The replacement block to use for swizzling the method. Its signature needs to be: return_type ^(id self, ...).
  
  */
 
@@ -181,7 +181,7 @@ OBJC_EXTERN BOOL deswizzleAll(void);
  Swizzle the specified instance method on this specific instance only.
  
  @param selector Selector of the method to swizzle.
- @param replacement The replacement block to use for swizzling the method. Its signature needs to be: return_type ^(id self, ...).
+ @param replacementProvider The replacement block to use for swizzling the method. Its signature needs to be: return_type ^(id self, ...).
  
  */
 - (void)swizzleMethod:(SEL)selector withReplacement:(JGMethodReplacementProvider)replacementProvider;


### PR DESCRIPTION
The version of clang in the latest SDK throws a warning when it sees a mismatch between a `@param` and the parameter name in the method declaration. 